### PR TITLE
Enumerate toRemove before iterating the Dictionary

### DIFF
--- a/Source/FootTrafficHeatmap/FootTrafficHeatmap.cs
+++ b/Source/FootTrafficHeatmap/FootTrafficHeatmap.cs
@@ -230,7 +230,7 @@ namespace TrafficHeatmap
 
         private void RemoveInvalidPawns()
         {
-            IEnumerable<Pawn> toRemove = this.pawnToCellCostGridMap.Keys.Where(pawn => !pawn.IsColonist || pawn.Dead);
+            IEnumerable<Pawn> toRemove = this.pawnToCellCostGridMap.Keys.Where(pawn => !pawn.IsColonist || pawn.Dead).ToList();
 
             if (toRemove.Any())
             {


### PR DESCRIPTION
There's a situation that can cause an InvalidOperationException in `RemoveInvalidPawns`. If you remove multiple pawns in a single tick, then the enumerator is invalidated after the first loop of the foreach.

The reason for this is that LINQ Where isn't executed immediately, but rather lazily as it's Enumerator is executed. This means that in the first loop of the foreach, it gets the first item, then removes it from the Dictionary. Then, when the second loop tries to start, the enumerator is invalid because of the first item being removed.

We can fix that by forcing an enumeration of the `toRemove` by forcing it into a List with `ToList()`. This forces the Where to go through the entire Dictionary first, _and then_ start the foreach where it removes the keys from the Dictionary. 

Thank you again for porting this to 1.5!